### PR TITLE
Prevent click after dragging

### DIFF
--- a/src/draggable_event_wrapper.jsx
+++ b/src/draggable_event_wrapper.jsx
@@ -79,6 +79,13 @@ export default () => (EventWrapper) => {
       const { dnd } = this.context;
       const { event } = this.props;
 
+      // Prevent a click from firing after dragging
+      const preventClick = (e) => {
+        e.stopImmediatePropagation();
+        e.currentTarget.removeEventListener('click', preventClick, false);
+      };
+      this.mc.element.addEventListener('click', preventClick, false);
+
       // Clean up added styles/listeners
       if (this.resetStyles) {
         this.resetStyles();

--- a/src/index.less
+++ b/src/index.less
@@ -5,7 +5,6 @@
 
     box-shadow: 0 8px 12px 0 rgba(0, 0, 0, .15);
     isolation: isolate;
-    pointer-events: none;
     transition: transform @transition-time, box-shadow @transition-time;
     z-index: 1000;
   }


### PR DESCRIPTION
Description
-----------
If the consumer is using a custom event component with a click handler
attached, the click would be fired after dragging an event. With this
change, clicks are prevented after the event has been dragged.

Related Pull Requests
---------------------

Testing Steps
-------------